### PR TITLE
Fix EOF exceptions in Gradle daemon when generating new metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # AtPlug releases
 
 ## [Unreleased]
+### Fixed
+- The Gradle daemon would throw `EOFException` when adding new components in a warm daemon due to [Jar URL caching](https://stackoverflow.com/questions/36517604/closing-a-jarurlconnection), now fixed. ([#4](https://github.com/diffplug/atplug/pull/4))
 
 ## [0.1.1] - 2022-02-19
 ### Fixed

--- a/atplug-plugin-gradle/src/main/java/com/diffplug/atplug/tooling/gradle/PlugGenerateTask.java
+++ b/atplug-plugin-gradle/src/main/java/com/diffplug/atplug/tooling/gradle/PlugGenerateTask.java
@@ -22,8 +22,6 @@ import com.diffplug.gradle.JRE;
 import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -161,8 +159,7 @@ public abstract class PlugGenerateTask extends DefaultTask {
 	private Manifest loadManifest() {
 		Manifest manifest = new Manifest();
 		if (manifestFile().isFile()) {
-			try (InputStream raw = new FileInputStream(manifestFile());
-					InputStream input = new BufferedInputStream(raw)) {
+			try (InputStream input = new BufferedInputStream(Files.newInputStream(manifestFile().toPath()))) {
 				manifest.read(input);
 			} catch (IOException e) {
 				throw new RuntimeException(e);
@@ -171,17 +168,16 @@ public abstract class PlugGenerateTask extends DefaultTask {
 		return manifest;
 	}
 
-	private void saveManifest(Manifest manifest) throws IOException {
+	private void saveManifest(Manifest manifest) {
 		FileMisc.mkdirs(manifestFile().getParentFile());
-		try (OutputStream raw = new FileOutputStream(manifestFile());
-				OutputStream output = new BufferedOutputStream(raw)) {
+		try (OutputStream output = new BufferedOutputStream(Files.newOutputStream(manifestFile().toPath()))) {
 			manifest.write(output);
 		} catch (IOException e) {
 			throw new RuntimeException(e);
 		}
 	}
 
-	private SortedMap<String, String> generate() throws Throwable {
+	private SortedMap<String, String> generate() {
 		PlugGeneratorJavaExecable input = new PlugGeneratorJavaExecable(new ArrayList<>(getClassesFolders().getFiles()), getJarsToLinkAgainst().getFiles());
 		if (getLauncher().isPresent()) {
 			WorkQueue workQueue = getWorkerExecutor().processIsolation(workerSpec -> {

--- a/atplug-runtime/src/main/java/com/diffplug/atplug/Metadata.kt
+++ b/atplug-runtime/src/main/java/com/diffplug/atplug/Metadata.kt
@@ -6,11 +6,8 @@
  */
 package com.diffplug.atplug
 
-import java.lang.annotation.Documented
-
 /** Marks that a method is used to generate metadata, and should therefore return a constant. */
-@Documented
-@kotlin.annotation.Retention(AnnotationRetention.SOURCE)
+@Retention(AnnotationRetention.SOURCE)
 @Target(
 		AnnotationTarget.FUNCTION, AnnotationTarget.PROPERTY_GETTER, AnnotationTarget.PROPERTY_SETTER)
 annotation class Metadata

--- a/atplug-runtime/src/main/java/com/diffplug/atplug/Plug.kt
+++ b/atplug-runtime/src/main/java/com/diffplug/atplug/Plug.kt
@@ -9,7 +9,7 @@ package com.diffplug.atplug
 import kotlin.reflect.KClass
 
 /** Annotation which signals that this class implements the given socket. */
-@kotlin.annotation.Retention(AnnotationRetention.BINARY)
+@Retention(AnnotationRetention.BINARY)
 @Target(AnnotationTarget.ANNOTATION_CLASS, AnnotationTarget.CLASS)
 annotation class Plug(
 		/** Socket type which this plug implements. */

--- a/atplug-runtime/src/main/java/com/diffplug/atplug/PlugInstanceMap.kt
+++ b/atplug-runtime/src/main/java/com/diffplug/atplug/PlugInstanceMap.kt
@@ -11,7 +11,7 @@ class PlugInstanceMap {
 	internal val instanceMap = mutableMapOf<PlugDescriptor, Any>()
 
 	fun putDescriptor(clazz: String, descriptor: PlugDescriptor) {
-		val descriptors = descriptorMap.computeIfAbsent(clazz) { mutableListOf<PlugDescriptor>() }
+		val descriptors = descriptorMap.computeIfAbsent(clazz) { mutableListOf() }
 		descriptors.add(descriptor)
 	}
 

--- a/atplug-runtime/src/main/java/com/diffplug/atplug/PlugRegistry.kt
+++ b/atplug-runtime/src/main/java/com/diffplug/atplug/PlugRegistry.kt
@@ -48,7 +48,7 @@ interface PlugRegistry {
 			if (registry is Eager) {
 				registry.setHarness(data)
 			} else {
-				throw AssertionError("Registry must not be set, was ${registry}")
+				throw AssertionError("Registry must not be set, was $registry")
 			}
 		}
 	}
@@ -77,7 +77,7 @@ interface PlugRegistry {
 										val component = parseComponent(asString, servicePath)
 										synchronized(this) {
 											data.putDescriptor(component.provides, component)
-											owners.get(component.provides)?.doRegister(component)
+											owners[component.provides]?.doRegister(component)
 										}
 									}
 								} catch (e: ZipException) {
@@ -103,8 +103,8 @@ interface PlugRegistry {
 		override fun <T> registerSocket(socketClass: Class<T>, socketOwner: SocketOwner<T>) {
 			synchronized(this) {
 				val prevOwner = owners.put(socketClass.name, socketOwner)
-				assert(prevOwner == null) { "Multiple owners registered for ${socketClass}" }
-				data.descriptorMap.get(socketClass.name)?.forEach(socketOwner::doRegister)
+				assert(prevOwner == null) { "Multiple owners registered for $socketClass" }
+				data.descriptorMap[socketClass.name]?.forEach(socketOwner::doRegister)
 			}
 		}
 
@@ -128,7 +128,7 @@ interface PlugRegistry {
 				"Class must have a no-arg constructor, but it didn't.  " +
 						clazz +
 						" " +
-						Arrays.asList(*clazz.constructors)
+						listOf(*clazz.constructors)
 			}
 			return constructor.newInstance() as T
 		}
@@ -138,12 +138,12 @@ interface PlugRegistry {
 		fun setHarness(newHarness: PlugInstanceMap?) {
 			val toRemove = lastHarness ?: data
 			toRemove.descriptorMap.forEach { (clazz, plugDescriptors) ->
-				owners.get(clazz)?.let { owner -> plugDescriptors.forEach(owner::doRemove) }
+				owners[clazz]?.let { owner -> plugDescriptors.forEach(owner::doRemove) }
 			}
 
 			val toAdd = newHarness ?: data
 			toAdd.descriptorMap.forEach { (clazz, plugDescriptors) ->
-				owners.get(clazz)?.let { owner -> plugDescriptors.forEach(owner::doRegister) }
+				owners[clazz]?.let { owner -> plugDescriptors.forEach(owner::doRegister) }
 			}
 			lastHarness = newHarness
 		}

--- a/atplug-runtime/src/main/java/com/diffplug/atplug/PlugRegistry.kt
+++ b/atplug-runtime/src/main/java/com/diffplug/atplug/PlugRegistry.kt
@@ -80,7 +80,7 @@ interface PlugRegistry {
 						try {
 							if (servicePath.isNotEmpty()) {
 								val asString = manifestUrl.toExternalForm()
-								val component = parseComponent(asString, servicePath, useCaches)
+								val component = parseComponent(asString, servicePath, allowCaching)
 								synchronized(this) {
 									data.putDescriptor(component.provides, component)
 									owners[component.provides]?.doRegister(component)

--- a/atplug-runtime/src/main/java/com/diffplug/atplug/SocketOwner.kt
+++ b/atplug-runtime/src/main/java/com/diffplug/atplug/SocketOwner.kt
@@ -6,7 +6,6 @@
  */
 package com.diffplug.atplug
 
-import java.io.EOFException
 import java.lang.Exception
 import java.lang.IllegalArgumentException
 import java.lang.RuntimeException
@@ -189,7 +188,6 @@ abstract class SocketOwner<T>(val socketClass: Class<T>) {
 					return generatorForSocket(socket)
 				}
 			} catch (e: Throwable) {
-				rethrowIfEOF(e)
 				firstAttempt = e
 			}
 			try {
@@ -197,19 +195,12 @@ abstract class SocketOwner<T>(val socketClass: Class<T>) {
 				val socket = socketOwnerClass.objectInstance!! as SocketOwner<T>
 				return generatorForSocket(socket)
 			} catch (secondAttempt: Throwable) {
-				rethrowIfEOF(secondAttempt)
 				val e =
 						IllegalArgumentException(
 								"To create metadata for `$socketClass` we need either a field `static final SocketOwner socket` or a kotlin `object Socket`.",
 								secondAttempt)
 				firstAttempt?.let(e::addSuppressed)
 				throw e
-			}
-		}
-
-		private fun rethrowIfEOF(exception: Throwable) {
-			if (rootCause(exception) is EOFException) {
-				throw Error("The JVM needs to be restarted (gradew --stop) to fix", exception)
 			}
 		}
 


### PR DESCRIPTION
When adding a new component inside a warm Gradle daemon, we would often get EOF exceptions which were due to [`JarURLConnection` using a cached version of the jar](https://stackoverflow.com/questions/36517604/closing-a-jarurlconnection). We now trap these errors and retry with caching disabled.

This error only takes place when generating metadata in a warm daemon, so it makes sense to keep caching enabled at prod-runtime.