### PR TITLE
Huge speedup by separating "find" from "generate"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # AtPlug releases
 
 ## [Unreleased]
+### Added
+- Cacheability, incremental task, and huge speed improvement. ([#66](https://github.com/diffplug/atplug/pull/66))
+  - `plugGenerate` refactored into `plugFind` followed by `plugGenerate` 
 ### Changed
 - Bump required JVM from 11 to 17. ([#63](https://github.com/diffplug/atplug/pull/63))
 - Detect Kotlin version rather than harcode it. ([#64](https://github.com/diffplug/atplug/pull/64))

--- a/atplug-plugin-gradle/src/main/java/com/diffplug/atplug/tooling/PlugGeneratorJavaExecable.kt
+++ b/atplug-plugin-gradle/src/main/java/com/diffplug/atplug/tooling/PlugGeneratorJavaExecable.kt
@@ -20,21 +20,21 @@ import java.io.File
 import java.util.*
 
 /** [PlugGenerator.PlugGenerator] in a [JavaExecable] form. */
-class PlugGeneratorJavaExecable(toSearch: List<File>?, toLinkAgainst: Set<File>?) : JavaExecable {
+class PlugGeneratorJavaExecable(
+		plugToSocket: Map<String, String>,
+		toSearch: List<File>,
+		toLinkAgainst: Set<File>
+) : JavaExecable {
 	// inputs
-	var toSearch: List<File>
-	var toLinkAgainst: Set<File>
+	var plugToSocket: Map<String, String> = LinkedHashMap(plugToSocket)
+	var toSearch: List<File> = ArrayList(toSearch)
+	var toLinkAgainst: Set<File> = LinkedHashSet(toLinkAgainst)
 
 	// outputs
 	@JvmField var atplugInf: SortedMap<String, String>? = null
 
-	init {
-		this.toSearch = ArrayList(toSearch)
-		this.toLinkAgainst = LinkedHashSet(toLinkAgainst)
-	}
-
 	override fun run() {
-		val metadataGen = PlugGenerator(toSearch, toLinkAgainst)
+		val metadataGen = PlugGenerator(plugToSocket, toSearch, toLinkAgainst)
 		atplugInf = metadataGen.atplugInf
 	}
 }

--- a/atplug-plugin-gradle/src/main/java/com/diffplug/atplug/tooling/gradle/FindPlugsTask.kt
+++ b/atplug-plugin-gradle/src/main/java/com/diffplug/atplug/tooling/gradle/FindPlugsTask.kt
@@ -1,0 +1,77 @@
+package com.diffplug.atplug.tooling.gradle
+
+import com.diffplug.atplug.tooling.PlugParser
+import java.io.File
+import java.nio.charset.StandardCharsets
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.tasks.*
+import org.gradle.work.*
+
+/**
+ * Incrementally scans compiled classes for @Plug usage and writes discovered plug classes into an
+ * output directory.
+ */
+@CacheableTask
+abstract class FindPlugsTask : DefaultTask() {
+	@get:CompileClasspath
+	@get:Incremental
+	@get:InputFiles
+	abstract val classesFolders: ConfigurableFileCollection
+
+	/** Directory where we will store discovered plugs in .txt files, etc. */
+	@get:OutputDirectory abstract val discoveredPlugsDir: DirectoryProperty
+
+	@TaskAction
+	fun findPlugs(inputChanges: InputChanges) {
+		// If not incremental, clear everything and rescan
+		if (!inputChanges.isIncremental) {
+			discoveredPlugsDir.get().asFile.deleteRecursively()
+		}
+
+		// Make sure our output directory exists
+		discoveredPlugsDir.get().asFile.mkdirs()
+
+		// For each changed file in classesFolders, determine if it has @Plug
+		for (change in inputChanges.getFileChanges(classesFolders)) {
+			if (!change.file.name.endsWith(".class")) {
+				continue
+			}
+			when (change.changeType) {
+				ChangeType.REMOVED -> {
+					// Remove old discovered data for this file
+					removeOldMetadata(change.file)
+				}
+				ChangeType.ADDED,
+				ChangeType.MODIFIED -> {
+					parseAndWriteMetadata(change.file)
+				}
+			}
+		}
+	}
+
+	private fun parseAndWriteMetadata(classFile: File) {
+		val parser = PlugParser()
+		parser.parse(classFile)
+		if (parser.hasPlug()) {
+			// For example: write a single line containing the discovered plug FQN
+			val discoveredFile = discoveredPlugsDir.file(parser.plugClassName + ".txt").get().asFile
+			discoveredFile.parentFile.mkdirs()
+			discoveredFile.writeText(
+					parser.plugClassName!! + "|" + parser.socketClassName!!, StandardCharsets.UTF_8)
+		} else {
+			// If previously discovered, remove it
+			removeOldMetadata(classFile)
+		}
+	}
+
+	private fun removeOldMetadata(classFile: File) {
+		// Remove any discovered file for the old .class
+		val possibleName = classFile.nameWithoutExtension + ".txt"
+		val discoveredFile = discoveredPlugsDir.file(possibleName).get().asFile
+		if (discoveredFile.exists()) {
+			discoveredFile.delete()
+		}
+	}
+}

--- a/atplug-plugin-gradle/src/main/java/com/diffplug/atplug/tooling/gradle/PlugGenerateTask.kt
+++ b/atplug-plugin-gradle/src/main/java/com/diffplug/atplug/tooling/gradle/PlugGenerateTask.kt
@@ -30,20 +30,15 @@ import java.util.jar.Manifest
 import javax.inject.Inject
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.FileCollection
 import org.gradle.api.plugins.JavaPluginExtension
 import org.gradle.api.provider.Property
-import org.gradle.api.tasks.Classpath
-import org.gradle.api.tasks.InputFiles
-import org.gradle.api.tasks.Internal
-import org.gradle.api.tasks.JavaExec
-import org.gradle.api.tasks.Nested
-import org.gradle.api.tasks.Optional
-import org.gradle.api.tasks.OutputDirectory
-import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.*
 import org.gradle.jvm.toolchain.JavaLauncher
 import org.gradle.jvm.toolchain.JavaToolchainService
 import org.gradle.process.JavaForkOptions
+import org.gradle.work.Incremental
 import org.gradle.workers.ProcessWorkerSpec
 import org.gradle.workers.WorkerExecutor
 
@@ -51,6 +46,8 @@ abstract class PlugGenerateTask : DefaultTask() {
 	@get:Optional @get:Nested abstract val launcher: Property<JavaLauncher>
 
 	@get:Inject abstract val workerExecutor: WorkerExecutor
+
+	@get:InputDirectory abstract val discoveredPlugsDir: DirectoryProperty
 
 	@get:InputFiles @get:Classpath abstract val jarsToLinkAgainst: ConfigurableFileCollection
 
@@ -60,7 +57,7 @@ abstract class PlugGenerateTask : DefaultTask() {
 	val atplugInfFolder: File
 		get() = File(resourcesFolder, PlugPlugin.ATPLUG_INF)
 
-	@InputFiles var classesFolders: FileCollection? = null
+	@get:Incremental @get:InputFiles abstract val classesFolders: ConfigurableFileCollection
 
 	init {
 		this.outputs.upToDateWhen {
@@ -74,20 +71,36 @@ abstract class PlugGenerateTask : DefaultTask() {
 		launcher.set(service.launcherFor(spec))
 	}
 
-	fun setClassesFolders(files: Iterable<File>) {
-		// if we don't copy, Gradle finds an implicit dependency which
-		// forces us to depend on `classes` even though we don't
-		val copy: MutableList<File> = ArrayList()
-		for (file in files) {
-			copy.add(file)
-		}
-		classesFolders = project.files(copy)
-	}
-
 	@TaskAction
 	fun build() {
+		// 1) Collect the discovered classes
+		val discoveredFiles =
+				discoveredPlugsDir.get().asFile.listFiles().orEmpty().filter {
+					it.isFile && it.name.endsWith(".txt")
+				}
+
+		// Turn them into a list of (plugClass, socketClass)
+		val discoveredPlugs =
+				discoveredFiles
+						.map { file ->
+							val line = file.readText(StandardCharsets.UTF_8).trim()
+							val split = line.split("|")
+							check(split.size == 2) { "Malformed discovered line in ${file.name}: '$line'" }
+							val (plugClassName, socketClassName) = split
+							plugClassName to socketClassName
+						}
+						.toMap()
+
+		// 2) Use reflection logic, now that we have jarsToLinkAgainst, to produce final metadata
+		//    This is where you'd adapt the old PlugGenerator invocation, but no scanning is needed
+		if (discoveredPlugs.isEmpty()) {
+			// no discovered plugs
+			FileMisc.cleanDir(atplugInfFolder)
+			return
+		}
+
 		// generate the metadata
-		val result = generate()
+		val result = generate(discoveredPlugs)
 
 		// clean out the ATPLUG-INF folder, and put the map's content into the folder
 		FileMisc.cleanDir(atplugInfFolder)
@@ -138,9 +151,10 @@ abstract class PlugGenerateTask : DefaultTask() {
 		}
 	}
 
-	private fun generate(): SortedMap<String, String> {
+	private fun generate(discoveredPlugs: Map<String, String>): SortedMap<String, String> {
 		val input =
-				PlugGeneratorJavaExecable(ArrayList(classesFolders!!.files), jarsToLinkAgainst.files)
+				PlugGeneratorJavaExecable(
+						discoveredPlugs, ArrayList(classesFolders.files), jarsToLinkAgainst.files)
 		return if (launcher.isPresent) {
 			val workQueue =
 					workerExecutor.processIsolation { workerSpec: ProcessWorkerSpec ->

--- a/atplug-plugin-gradle/src/main/java/com/diffplug/atplug/tooling/gradle/PlugPlugin.kt
+++ b/atplug-plugin-gradle/src/main/java/com/diffplug/atplug/tooling/gradle/PlugPlugin.kt
@@ -51,7 +51,7 @@ class PlugPlugin : Plugin<Project> {
 				}
 
 		val findPlugsTask =
-				project.tasks.register("findPlugs", FindPlugsTask::class.java) {
+				project.tasks.register("plugFind", FindPlugsTask::class.java) {
 					it.classesFolders.setFrom(main.output.classesDirs)
 					it.discoveredPlugsDir.set(project.layout.buildDirectory.dir("foundPlugs"))
 					// dep on java
@@ -65,7 +65,7 @@ class PlugPlugin : Plugin<Project> {
 				}
 
 		val generatePlugsTask =
-				project.tasks.register("generatePlugs", PlugGenerateTask::class.java) {
+				project.tasks.register("plugGenerate", PlugGenerateTask::class.java) {
 					it.discoveredPlugsDir.set(findPlugsTask.flatMap { it.discoveredPlugsDir })
 					it.classesFolders.setFrom(main.output.classesDirs)
 					it.jarsToLinkAgainst.setFrom(plugGenConfig)

--- a/atplug-plugin-gradle/src/test/java/com/diffplug/atplug/tooling/PlugGeneratorTest.kt
+++ b/atplug-plugin-gradle/src/test/java/com/diffplug/atplug/tooling/PlugGeneratorTest.kt
@@ -33,6 +33,11 @@ class PlugGeneratorTest : ResourceHarness() {
 	fun generateMetadata() {
 		val maps =
 				PlugGenerator.generate(
+						mapOf(
+								"com.diffplug.atplug.Apple" to "com.diffplug.atplug.Fruit",
+								"com.diffplug.atplug.Orange" to "com.diffplug.atplug.Fruit",
+								"com.diffplug.atplug.Shape\$Circle" to "com.diffplug.atplug.Shape",
+								"com.diffplug.atplug.Shape\$Square" to "com.diffplug.atplug.Shape"),
 						listOf("java", "kotlin").map { File("../atplug-runtime/build/classes/$it/test") },
 						deps())
 		Assertions.assertEquals(


### PR DESCRIPTION
We now support caching and incremental by splitting apart finding `@Plug` from generating the metadata.